### PR TITLE
[ breaking ] Change order of arguments in `tailRecM`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # idris2-tailrec : Total stack-safe monadic Recursion in Idris2
 
 Writing recursive functions that do not overflow the stack
-can be challenging. The Javascript backends in Idris2
+can be challenging. The JavaScript backends in Idris2
 optimize mutually tail-recursive
 functions into while loops, which makes them use constant stack space.
 Chez scheme, the target of the default backend


### PR DESCRIPTION
The more I work with the `tailrec` library, the more I get annoyed that the order of arguments in the `Cont` constructor and in the `tailRecM` function is different. Moreover, I like the order on `Cont` and dislike the order in `tailRecM`, because the former one has everything about seed (seed itself and accessibility proof) and after that it has an accumulating state argument, while the current `tailRecM` has ragged order: first the seed, then accumulating state and then a proof about the seed.

@stefan-hoeck I'm aware, that this will break your libraries, but I searched and haven't found a lot of breakage, so could be a good time to do this. I can make PRs to your downstream libraries if you would approve this change.

UPD: Additionally, depict in the readme changes from #1.