### PR TITLE
[ new ] Add a named non-tail-recursive implementation

### DIFF
--- a/src/Control/MonadRec.idr
+++ b/src/Control/MonadRec.idr
@@ -105,6 +105,14 @@ trSized :  MonadRec m
         -> m b
 trSized x ini = tailRecM x (sizeAccessible x) ini
 
+||| This is NOT a tail-recursive implementation, allowing any monad be used
+||| with the same API as if it is tail-recursive. Avoid using it at all costs!
+export
+[NonStackSafe] Monad m => MonadRec m where
+  tailRecM seed (Access acc) init step = step seed init >>= \case
+    Cont seed2 prf vst => tailRecM seed2 (acc seed2 prf) vst step
+    Done vres          => pure vres
+
 --------------------------------------------------------------------------------
 --          Base Implementations
 --------------------------------------------------------------------------------


### PR DESCRIPTION
When using `tailrec`, I found myself at first implementing two variants of runners, one for general `Monad` and one for `MonadRec`, having documentation comments preferring `MonadRec`. After that I realised that supporting two very similar implementations is not worth it, and added a `NoTailRec` (or `NonStackSafe`) named instance allowing to use `MonadRec`-based function with any `Monad`. Then I realised that this pattern is going to repeat in several places, so I suggest to have it in the library itself.